### PR TITLE
Update apply() in LaravelFilter

### DIFF
--- a/src/LaravelFilter.php
+++ b/src/LaravelFilter.php
@@ -104,8 +104,12 @@ final class LaravelFilter
         $subject = $this->subject;
 
         foreach ($this->filters as $filterName => $value) {
-            if (empty($value)) {
+            if (is_array($value) && empty($value)) {
                 continue;
+            }
+            
+            if (! isset($value)) {
+                continue; 
             }
 
             $name = Str::camel($filterName);


### PR DESCRIPTION
This PR fixes the problem where:
- The filter query did not run when parameter query is `0` or `false` in case of filtering boolean column (this is done by checking if non-array `$value` is set)
- If parameter is in array type, since `isset($value)` would return true if `$value` is empty array, additional condition to check if `$value` is a non-empty array is added